### PR TITLE
Implement fileless execution and remove xmltodict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ pyinstaller==5.3
 pyinstaller-hooks-contrib==2022.8
 pywin32-ctypes==0.2.0
 requests==2.28.1
-xmltodict==0.13.0


### PR DESCRIPTION
Apologies for the double-pull, didn't have time on Friday to dig into this as deeply as I wanted.

Updated the main script to utilize a combination of regex and piping the stdout from the commands to get SSIDS and their keys. Removed import for xmltodict as a result of this update and updated requirements.txt to match.

This now runs solely in memory without ever touching the local disk.